### PR TITLE
Fix for plotting point features without gradient

### DIFF
--- a/web/static/styles.js
+++ b/web/static/styles.js
@@ -60,7 +60,7 @@ function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, i
               image: new ol.style.Circle({
                 radius: 3, // Default point size
                 fill: new ol.style.Fill({
-                  color: fillColor,
+                  color: layerColor,
                 }),
               }),
               zIndex: 10, // Higher zIndex so points appear above polygons


### PR DESCRIPTION
Updated styles.js to fix issue of points without gradient being plotted due to undefined fillColor variable