### PR TITLE
Add phases of the Joint Office of Energy and Transport's ZEF corridor infrastructure plan

### DIFF
--- a/web/static/map.js
+++ b/web/static/map.js
@@ -335,7 +335,6 @@ async function updateSelectedLayers() {
     await Promise.all(loadingPromises);
 
     // Sort selectedLayers (now including the sub-layers)
-    console.log(selectedLayers)
     selectedLayers.sort(compareLayers);
 
     // Hide any non-selected layers

--- a/web/static/map.js
+++ b/web/static/map.js
@@ -445,8 +445,8 @@ function updateLegend() {
           symbolContainer.style.marginRight = "40px";
 
           const gradient = ctx.createLinearGradient(0, 0, 50, 0);
-          gradient.addColorStop(0, "rgb(255, 255, 255)");
-          gradient.addColorStop(1, `rgb(255, 0, 0)`);
+          gradient.addColorStop(0, "rgb(255, 255, 255)"); // White for low values
+          gradient.addColorStop(1, `rgb(0, 0, 255)`); // Blue for high values
           ctx.fillStyle = gradient;
           ctx.fillRect(0, 0, 50, 10);
           symbolContainer.appendChild(canvas);
@@ -577,8 +577,8 @@ function updateLegend() {
               symbolContainer.appendChild(minDiv);
 
               // Canvas to draw points
-              const minPointColor = 'blue';  // Color for minimum value
-              const maxPointColor = 'red'; // Color for maximum value
+              const minPointColor = 'lightblue';  // Light blue for minimum value
+              const maxPointColor = 'blue'; // Dark blue for maximum value
 
               // Create canvas for the minimum point size
               const minPointCanvas = document.createElement("canvas");

--- a/web/static/name_maps.js
+++ b/web/static/name_maps.js
@@ -431,10 +431,10 @@ export const geojsonColors = {
   'Savings from Pooled Charging Infrastructure': 'red',
   'Principal Ports': 'purple',
 
-  'ZEF Corridor Strategy Phase 1 Hubs': '#FF7F50',       // Dark Red for Hubs
-  'ZEF Corridor Strategy Phase 2 Hubs': '#FF7F50',
-  'ZEF Corridor Strategy Phase 3 Hubs': '#FF7F50',
-  'ZEF Corridor Strategy Phase 4 Hubs': '#FF7F50',
+  'ZEF Corridor Strategy Phase 1 Hubs': '#ffa500',       // Dark Red for Hubs
+  'ZEF Corridor Strategy Phase 2 Hubs': '#ffa500',
+  'ZEF Corridor Strategy Phase 3 Hubs': '#ffa500',
+  'ZEF Corridor Strategy Phase 4 Hubs': '#ffa500',
 
   'ZEF Corridor Strategy Phase 1 Corridors': 'Purple',  // Dark Blue for Corridors
   'ZEF Corridor Strategy Phase 2 Corridors': 'Purple',

--- a/web/static/name_maps.js
+++ b/web/static/name_maps.js
@@ -364,6 +364,19 @@ export let selectedFaf5Options = {
     'Commodity': 'All'
 };
 
+export const zefOptions = {
+  'Phase': {
+    'Phase 1': '1',
+    'Phase 2': '2',
+    'Phase 3': '3',
+    'Phase 4': '4'
+    },
+};
+
+export let selectedZefOptions = {
+    'Phase': 'Phase 1'
+};
+
 // Key: geojson name, Value: color to use
 export const geojsonColors = {
   'Truck Imports and Exports': 'red',
@@ -388,6 +401,7 @@ export const geojsonColors = {
   'LPG Stations': 'cyan',
   'Savings from Pooled Charging Infrastructure': 'red',
   'Principal Ports': 'purple',
+  'National Zero-Emission Freight Corridor Strategy': 'green',
 };
 
 // Key: geojson name, Value: either 'area' (indicating it's an area feature) or [feature type: category], where each feature type can be divided into several categories
@@ -426,6 +440,7 @@ export const geojsonTypes = {
   'Total Cost of Truck Ownership': 'area',
   'Grid Generation and Capacity': 'area',
   'Energy Demand from Electrified Trucking': 'area',
+  'National Zero-Emission Freight Corridor Strategy': ['highway', 'infra'],
 };
 
 export const dataInfo = {
@@ -461,5 +476,6 @@ export const dataInfo = {
   'Total Cost of Truck Ownership': "Estimated lifecycle total cost of ownership per mile for the Tesla Semi due to truck purchase, charging, labor, maintenance, insurance and other operating costs. Charging costs are evaluated using state-level commercial electricity price and demand charge. Costs are calculated using the model developed by <a href='https://chemrxiv.org/engage/chemrxiv/article-details/656e4691cf8b3c3cd7c96810'>Sader et al.</a>, calibrated to <a href='https://runonless.com/run-on-less-electric-depot-reports/'>NACFE Run on Less data</a> for the Tesla Semi from the 2023 PepsiCo Semi pilot.<br><br><a href='https://github.com/mcsc-impact-climate/Green_Trucking_Analysis'>Link to Git repo with code used to produce these layers</a>",
   'Grid Generation and Capacity': "Grid electricity generation and net summer power capacity by state for 2022, along with estimated theoretical maximum generation capacity and its difference and ratio relative to the actual grid electricity generation. Theoretical maximum electricity generation capacity is obtained under the assumption that the grid operates at its net summer power capacity year-round. <br><br>Data is obtained from the EIA's <a href='https://www.eia.gov/electricity/data/state/'>state-level electricity database</a>.<br><a href='https://www.eia.gov/electricity/data/state/annual_generation_state.xls'>Link to download annual generation data</a><br><a href='https://www.eia.gov/electricity/data/state/existcapacity_annual.xlsx'>Link to download net summer power capacity data</a>",
   'Energy Demand from Electrified Trucking': "Total energy demand from electrified trucking (in MWh), assuming all 2022 trucking operations in the state are electrified. This is evaluated using the FAF5 highway flows (see Highway Flows layer for details), along with payload-based energy economy calibrated to the Tesla Semi (code and details for Tesla Semi calibration can be found in the following GitHub repos <a href='https://github.com/mcsc-impact-climate/PepsiCo_NACFE_Analysis'>Repo 1</a>, <a href='https://github.com/mcsc-impact-climate/Green_Trucking_Analysis'>Repo 2</a>).<br><br>To assess the capacity of the grid to support electrified trucking, you can also change the gradient attribute to show the energy demand from electrified trucking as a percent of one of the following measures of grid capacity (see 'Grid Generation and Capacity' layer for details): <ul><li>Total electricity generated in the state in 2022</li><li>Total theoretical generating capacity of the state in 2022 (MWh), assuming the grid ran at its peak summer capacity year-round </li><li>Theoretical excess generating capacity (MWh). This is quantified as the difference between the total theoretical generating capacity and the actual electricity generated in 2022.</li></ul>",
+    'National Zero-Emission Freight Corridor Strategy': "zzz"
 };
 

--- a/web/static/name_maps.js
+++ b/web/static/name_maps.js
@@ -415,7 +415,21 @@ export const geojsonColors = {
   'LPG Stations': 'cyan',
   'Savings from Pooled Charging Infrastructure': 'red',
   'Principal Ports': 'purple',
-  'National Zero-Emission Freight Corridor Strategy': 'green',
+
+  'ZEF_Corridor_Strategy_Phase1_Hubs': '#FF7F50',       // Dark Red for Hubs
+  'ZEF_Corridor_Strategy_Phase2_Hubs': '#FF7F50',
+  'ZEF_Corridor_Strategy_Phase3_Hubs': '#FF7F50',
+  'ZEF_Corridor_Strategy_Phase4_Hubs': '#FF7F50',
+
+  'ZEF_Corridor_Strategy_Phase1_Corridors': 'DarkBlue',  // Dark Blue for Corridors
+  'ZEF_Corridor_Strategy_Phase2_Corridors': 'DarkBlue',
+  'ZEF_Corridor_Strategy_Phase3_Corridors': 'DarkBlue',
+  'ZEF_Corridor_Strategy_Phase4_Corridors': 'DarkBlue',
+
+  'ZEF_Corridor_Strategy_Phase1_Facilities': 'Green', // Dark Green for Facilities
+  'ZEF_Corridor_Strategy_Phase2_Facilities': 'Green',
+  'ZEF_Corridor_Strategy_Phase3_Facilities': 'Green',
+  'ZEF_Corridor_Strategy_Phase4_Facilities': 'Green',
 };
 
 // Key: geojson name, Value: either 'area' (indicating it's an area feature) or [feature type: category], where each feature type can be divided into several categories
@@ -454,7 +468,7 @@ export const geojsonTypes = {
   'Total Cost of Truck Ownership': 'area',
   'Grid Generation and Capacity': 'area',
   'Energy Demand from Electrified Trucking': 'area',
-  'National Zero-Emission Freight Corridor Strategy': ['highway', 'infra'],
+  'National ZEF Corridor Strategy': ['highway', 'infra'],
 };
 
 export const dataInfo = {
@@ -490,6 +504,7 @@ export const dataInfo = {
   'Total Cost of Truck Ownership': "Estimated lifecycle total cost of ownership per mile for the Tesla Semi due to truck purchase, charging, labor, maintenance, insurance and other operating costs. Charging costs are evaluated using state-level commercial electricity price and demand charge. Costs are calculated using the model developed by <a href='https://chemrxiv.org/engage/chemrxiv/article-details/656e4691cf8b3c3cd7c96810'>Sader et al.</a>, calibrated to <a href='https://runonless.com/run-on-less-electric-depot-reports/'>NACFE Run on Less data</a> for the Tesla Semi from the 2023 PepsiCo Semi pilot.<br><br><a href='https://github.com/mcsc-impact-climate/Green_Trucking_Analysis'>Link to Git repo with code used to produce these layers</a>",
   'Grid Generation and Capacity': "Grid electricity generation and net summer power capacity by state for 2022, along with estimated theoretical maximum generation capacity and its difference and ratio relative to the actual grid electricity generation. Theoretical maximum electricity generation capacity is obtained under the assumption that the grid operates at its net summer power capacity year-round. <br><br>Data is obtained from the EIA's <a href='https://www.eia.gov/electricity/data/state/'>state-level electricity database</a>.<br><a href='https://www.eia.gov/electricity/data/state/annual_generation_state.xls'>Link to download annual generation data</a><br><a href='https://www.eia.gov/electricity/data/state/existcapacity_annual.xlsx'>Link to download net summer power capacity data</a>",
   'Energy Demand from Electrified Trucking': "Total energy demand from electrified trucking (in MWh), assuming all 2022 trucking operations in the state are electrified. This is evaluated using the FAF5 highway flows (see Highway Flows layer for details), along with payload-based energy economy calibrated to the Tesla Semi (code and details for Tesla Semi calibration can be found in the following GitHub repos <a href='https://github.com/mcsc-impact-climate/PepsiCo_NACFE_Analysis'>Repo 1</a>, <a href='https://github.com/mcsc-impact-climate/Green_Trucking_Analysis'>Repo 2</a>).<br><br>To assess the capacity of the grid to support electrified trucking, you can also change the gradient attribute to show the energy demand from electrified trucking as a percent of one of the following measures of grid capacity (see 'Grid Generation and Capacity' layer for details): <ul><li>Total electricity generated in the state in 2022</li><li>Total theoretical generating capacity of the state in 2022 (MWh), assuming the grid ran at its peak summer capacity year-round </li><li>Theoretical excess generating capacity (MWh). This is quantified as the difference between the total theoretical generating capacity and the actual electricity generated in 2022.</li></ul>",
-    'National Zero-Emission Freight Corridor Strategy': "zzz"
+  'National ZEF Corridor Strategy': "This layer visualizes the National Zero-Emission Freight Corridor Strategy, a framework developed by the U.S. Joint Office of Energy and Transportation to support the coordinated deployment of medium- and heavy-duty zero-emission vehicle (ZEV) infrastructure along critical freight corridors. The strategy, outlined in the publication <a href='https://driveelectric.gov/files/zef-corridor-strategy.pdf'>National Zero-Emission Freight Corridor Strategy</a>, identifies priority corridors and infrastructure investment needs to accelerate the transition to zero-emission medium- and heavy-duty vehicles. <br><br>For more details, refer to the official report: <a href='https://driveelectric.gov/files/zef-corridor-strategy.pdf'>National Zero-Emission Freight Corridor Strategy</a> (Joint Office of Energy and Transportation, 2024)."
+
 };
 

--- a/web/static/name_maps.js
+++ b/web/static/name_maps.js
@@ -108,6 +108,21 @@ export const legendLabels = {
     'Propane': 'Incentives and Regulations (Propane)',
     'Renewable': 'Incentives and Regulations (Renewable Diesel)',
 //    'Emissions': 'Incentives and Regulations (Emissions)',
+
+    'ZEF Corridor Strategy Phase 1 Hubs': 'ZEF Hubs (Phase 1)',
+    'ZEF Corridor Strategy Phase 2 Hubs': 'ZEF Hubs (Phase 2)',
+    'ZEF Corridor Strategy Phase 3 Hubs': 'ZEF Hubs (Phase 3)',
+    'ZEF Corridor Strategy Phase 4 Hubs': 'ZEF Hubs (Phase 4)',
+    
+    'ZEF Corridor Strategy Phase 1 Corridors': 'ZEF Corridors (Phase 1)',
+    'ZEF Corridor Strategy Phase 2 Corridors': 'ZEF Corridors (Phase 2)',
+    'ZEF Corridor Strategy Phase 3 Corridors': 'ZEF Corridors (Phase 3)',
+    'ZEF Corridor Strategy Phase 4 Corridors': 'ZEF Corridors (Phase 4)',
+    
+    'ZEF Corridor Strategy Phase 1 Facilities': 'ZEF Facilities (Phase 1)',
+    'ZEF Corridor Strategy Phase 2 Facilities': 'ZEF Facilities (Phase 2)',
+    'ZEF Corridor Strategy Phase 3 Facilities': 'ZEF Facilities (Phase 3)',
+    'ZEF Corridor Strategy Phase 4 Facilities': 'ZEF Facilities (Phase 4)',
  },
     
   'Savings from Pooled Charging Infrastructure': {
@@ -416,20 +431,20 @@ export const geojsonColors = {
   'Savings from Pooled Charging Infrastructure': 'red',
   'Principal Ports': 'purple',
 
-  'ZEF_Corridor_Strategy_Phase1_Hubs': '#FF7F50',       // Dark Red for Hubs
-  'ZEF_Corridor_Strategy_Phase2_Hubs': '#FF7F50',
-  'ZEF_Corridor_Strategy_Phase3_Hubs': '#FF7F50',
-  'ZEF_Corridor_Strategy_Phase4_Hubs': '#FF7F50',
+  'ZEF Corridor Strategy Phase 1 Hubs': '#FF7F50',       // Dark Red for Hubs
+  'ZEF Corridor Strategy Phase 2 Hubs': '#FF7F50',
+  'ZEF Corridor Strategy Phase 3 Hubs': '#FF7F50',
+  'ZEF Corridor Strategy Phase 4 Hubs': '#FF7F50',
 
-  'ZEF_Corridor_Strategy_Phase1_Corridors': 'DarkBlue',  // Dark Blue for Corridors
-  'ZEF_Corridor_Strategy_Phase2_Corridors': 'DarkBlue',
-  'ZEF_Corridor_Strategy_Phase3_Corridors': 'DarkBlue',
-  'ZEF_Corridor_Strategy_Phase4_Corridors': 'DarkBlue',
+  'ZEF Corridor Strategy Phase 1 Corridors': 'DarkBlue',  // Dark Blue for Corridors
+  'ZEF Corridor Strategy Phase 2 Corridors': 'DarkBlue',
+  'ZEF Corridor Strategy Phase 3 Corridors': 'DarkBlue',
+  'ZEF Corridor Strategy Phase 4 Corridors': 'DarkBlue',
 
-  'ZEF_Corridor_Strategy_Phase1_Facilities': 'Green', // Dark Green for Facilities
-  'ZEF_Corridor_Strategy_Phase2_Facilities': 'Green',
-  'ZEF_Corridor_Strategy_Phase3_Facilities': 'Green',
-  'ZEF_Corridor_Strategy_Phase4_Facilities': 'Green',
+  'ZEF Corridor Strategy Phase 1 Facilities': 'Green', // Dark Green for Facilities
+  'ZEF Corridor Strategy Phase 2 Facilities': 'Green',
+  'ZEF Corridor Strategy Phase 3 Facilities': 'Green',
+  'ZEF Corridor Strategy Phase 4 Facilities': 'Green',
 };
 
 // Key: geojson name, Value: either 'area' (indicating it's an area feature) or [feature type: category], where each feature type can be divided into several categories

--- a/web/static/name_maps.js
+++ b/web/static/name_maps.js
@@ -89,6 +89,7 @@ export const legendLabels = {
     'Tot Trips': 'Highway Freight Flows (daily trips/link)'},
   'Highway Flows (SU)': {
     'Tot Tons': 'Single-unit Highway Freight Flows (annual kilo-tons/link)',
+    'Tot Tons': 'Single-unit Highway Freight Flows (annual kilo-tons/link)',
     'Tot Trips': 'Single-unit Highway Freight Flows (daily trips/link)'},
   'Highway Flows (CU)': {
     'Tot Tons': 'Combined-unit Highway Freight Flows (annual kilo-tons/link)',
@@ -276,7 +277,7 @@ export const gridEmissionsOptions = {
 };
 
 export let selectedGridEmissionsOptions = {
-    'Visualize By': 'State'
+    'Visualize By': 'eia2022_state'
 };
 
 export const hourlyEmissionsOptions = {
@@ -361,7 +362,7 @@ export const faf5Options = {
 };
 
 export let selectedFaf5Options = {
-    'Commodity': 'All'
+    'Commodity': 'all'
 };
 
 export const zefOptions = {
@@ -374,7 +375,7 @@ export const zefOptions = {
 };
 
 export let selectedZefOptions = {
-    'Phase': 'Phase 1'
+    'Phase': '1'
 };
 
 export const zefSubLayerOptions = {

--- a/web/static/name_maps.js
+++ b/web/static/name_maps.js
@@ -436,10 +436,10 @@ export const geojsonColors = {
   'ZEF Corridor Strategy Phase 3 Hubs': '#FF7F50',
   'ZEF Corridor Strategy Phase 4 Hubs': '#FF7F50',
 
-  'ZEF Corridor Strategy Phase 1 Corridors': 'DarkBlue',  // Dark Blue for Corridors
-  'ZEF Corridor Strategy Phase 2 Corridors': 'DarkBlue',
-  'ZEF Corridor Strategy Phase 3 Corridors': 'DarkBlue',
-  'ZEF Corridor Strategy Phase 4 Corridors': 'DarkBlue',
+  'ZEF Corridor Strategy Phase 1 Corridors': 'Purple',  // Dark Blue for Corridors
+  'ZEF Corridor Strategy Phase 2 Corridors': 'Purple',
+  'ZEF Corridor Strategy Phase 3 Corridors': 'Purple',
+  'ZEF Corridor Strategy Phase 4 Corridors': 'Purple',
 
   'ZEF Corridor Strategy Phase 1 Facilities': 'Green', // Dark Green for Facilities
   'ZEF Corridor Strategy Phase 2 Facilities': 'Green',

--- a/web/static/name_maps.js
+++ b/web/static/name_maps.js
@@ -377,6 +377,19 @@ export let selectedZefOptions = {
     'Phase': 'Phase 1'
 };
 
+export const zefSubLayerOptions = {
+  // We’ll just store booleans whether user wants them visible or not
+  'Corridors': true,
+  'Facilities': true,
+  'Hubs': true,
+};
+
+export let selectedZefSubLayers = {
+  'Corridors': true,
+  'Facilities': true,
+  'Hubs': true
+};
+
 // Key: geojson name, Value: color to use
 export const geojsonColors = {
   'Truck Imports and Exports': 'red',

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -451,6 +451,23 @@ body {
   font-size: 14px; /* Adjust the font size as needed */
 }
 
+/* Keep checkboxes in one row with proper spacing */
+.zef-sub-layers-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center; /* Ensures checkboxes align with the label */
+  margin-top: 20px; /* Increase spacing between checkboxes */
+  margin-right: 30px; /* Increase spacing between checkboxes */
+}
+
+/* Ensure the label and checkboxes are aligned properly */
+.zef-sub-layers-container label,
+.zef-sub-layers-container input[type="checkbox"] {
+  vertical-align: middle; /* Aligns checkboxes with the label */
+  margin-right: 10px; /* Add right margin for spacing */
+}
+
+
 .lds-default {
   display: inline-block;
   position: relative;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -431,6 +431,26 @@ body {
   font-size: 14px; /* Adjust the font size as needed */
 }
 
+/* Style for the phase dropdown container */
+.phase-dropdown-container {
+  display: flex;
+  justify-content: left; /* Center the content horizontally */
+  align-items: center; /* Center the content vertically */
+  margin-top: 20px; /* Adjust the top margin as needed */
+}
+
+/* Style for the label */
+.phase-dropdown-container label {
+  margin-right: 10px; /* Add right margin for spacing */
+}
+
+/* Style for the "Visualize By" dropdown */
+#phase-dropdown {
+  width: 60%; /* Make the dropdown fill the available width */
+  padding: 5px; /* Add some padding to the dropdown */
+  font-size: 14px; /* Adjust the font size as needed */
+}
+
 .lds-default {
   display: inline-block;
   position: relative;

--- a/web/static/styles.js
+++ b/web/static/styles.js
@@ -25,7 +25,6 @@ function generateDistinctColor() {
 }
 
 function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, isHover = false) {
-  //console.log('print');
   return function(feature) {
     const attributeKey = layerName;
     const useGradient = layerName in selectedGradientAttributes;
@@ -33,140 +32,175 @@ function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, i
     let gradientType = '';
     let attributeValue = '';
     if (useGradient) {
-        attributeName = selectedGradientAttributes[layerName];
-        gradientType = selectedGradientTypes[layerName];
-        attributeValue = feature.get(attributeName);
+      attributeName = selectedGradientAttributes[layerName];
+      gradientType = selectedGradientTypes[layerName];
+      attributeValue = feature.get(attributeName);
     }
     const bounds = attributeBounds[layerName]; // Get the bounds for this specific geojson
     
     // If the layer is pre-defined, set it to its defined color, or default to yellow
     let layerColor = '';
     if (layerName in dataInfo) {
-      layerColor = geojsonColors[layerName] || 'yellow'; // Fetch color from dictionary, or default to yellow
-    }
-    // Otherwise, set the color dynamically
-    else {
+      layerColor = geojsonColors[layerName] || 'yellow'; // Fetch color from dictionary, or default
+    } else {
+      // Otherwise, set the color dynamically
       layerColor = assignColorToLayer(layerName);
     }
-    //console.log(geojsonColors[layerName]);
-    const geometryType = feature.getGeometry().getType();
 
+    const geometryType = feature.getGeometry().getType();
     
+    // ---- 1) POINTS ----
     if (geometryType === 'Point' || geometryType === 'MultiPoint') {
-      const fillColor = 'green';
       if (useGradient && bounds) {
         if (gradientType === 'size') {
-            const minSize = 2; // Minimum point size
-            const maxSize = 10; // Maximum point size
-
-            // Calculate the point size based on the attribute value and bounds
-            const pointSize = minSize + ((maxSize - minSize) * (attributeValue - bounds.min) / (bounds.max - bounds.min));
-
-            return new ol.style.Style({
-              image: new ol.style.Circle({
-                radius: pointSize,
-                fill: new ol.style.Fill({
-                  color: layerColor,
-                }),
+          const minSize = 2; // Minimum point size
+          const maxSize = 10; // Maximum point size
+          const pointSize = minSize + ((maxSize - minSize) *
+            (attributeValue - bounds.min) / (bounds.max - bounds.min));
+          return new ol.style.Style({
+            image: new ol.style.Circle({
+              radius: pointSize,
+              fill: new ol.style.Fill({
+                color: layerColor,
               }),
-              zIndex: 10, // Higher zIndex so points appear above polygons
-            });
-          }
-        else if (gradientType === 'color') {
-            const component = Math.floor(255 * (attributeValue - bounds.min) / (bounds.max - bounds.min));
-            const pointColor = `rgb(${component}, 0, ${255 - component})`;
+            }),
+            zIndex: 10,
+          });
+        } else if (gradientType === 'color') {
+          const component = Math.floor(255 *
+            (attributeValue - bounds.min) / (bounds.max - bounds.min));
+          const pointColor = `rgb(${component}, 0, ${255 - component})`;
 
-           return new ol.style.Style({
-              image: new ol.style.Circle({
-                radius: 3,
-                fill: new ol.style.Fill({
-                  color: pointColor,
-                }),
+          return new ol.style.Style({
+            image: new ol.style.Circle({
+              radius: 3,
+              fill: new ol.style.Fill({
+                color: pointColor,
               }),
-              zIndex: 10, // Higher zIndex so points appear above polygons
-            });
+            }),
+            zIndex: 10,
+          });
         }
       }
-      else {
-            // Use a default point style if no gradient or bounds are available
-            return new ol.style.Style({
-              image: new ol.style.Circle({
-                radius: 3, // Default point size
-                fill: new ol.style.Fill({
-                  color: layerColor,
-                }),
-              }),
-              zIndex: 10, // Higher zIndex so points appear above polygons
-            });
-          }
-    } else if (geometryType === 'Polygon' || geometryType === 'MultiPolygon') {
-      if (useGradient && bounds) {
-        const component = Math.floor(255 - (255 * (attributeValue - bounds.min) / (bounds.max - bounds.min)));
-        const fillColor = `rgb(255, ${component}, ${component})`;
-
+      // Default point style if no gradient or bounds are available
       return new ol.style.Style({
-        stroke: new ol.style.Stroke({
-          color: boundaryColor,
-          width: boundaryWidth,
+        image: new ol.style.Circle({
+          radius: 3,
+          fill: new ol.style.Fill({
+            color: layerColor,
+          }),
         }),
-        fill: new ol.style.Fill({
-          color: fillColor,
-        }),
-        zIndex: 1 // Lower zIndex so polygons appear below points
-      });
-    } else {
-        return new ol.style.Style({
-          stroke: new ol.style.Stroke({
-          color: boundaryColor,
-          width: boundaryWidth,
-        }),
-        fill: new ol.style.Fill({
-          color: layerColor,
-        }),
-        zIndex: 1 // Lower zIndex so polygons appear below points
+        zIndex: 10,
       });
     }
 
-  }  else if (geometryType === 'LineString' || geometryType === 'MultiLineString') {
-      if (useGradient && bounds) {  // Apply varying width only if gradientFlags is true and bounds are defined
-        // Normalize within range 1 to 10
-        const normalizedWidth = 1 + 9 * ((attributeValue - bounds.min) / (bounds.max - bounds.min));
+    // ---- 2) POLYGONS ----
+    else if (geometryType === 'Polygon' || geometryType === 'MultiPolygon') {
+      // Check if this is a "_Hubs" layer so that we can do alpha=0.5
+      const isHubs = layerName.includes('_Hubs');
 
+      if (useGradient && bounds) {
+        // We'll apply a simple red/white gradient to the polygon, but for Hubs,
+        // also add alpha=0.5 to the fill color
+        const component = Math.floor(
+          255 - (255 * (attributeValue - bounds.min) / (bounds.max - bounds.min))
+        );
+        // "rgb(255, component, component)" => default
+        // But for Hubs, do "rgba(255, component, component, 0.5)"
+        let fillColor = isHubs
+          ? `rgba(255, ${component}, ${component}, 0.5)`
+          : `rgb(255, ${component}, ${component})`;
+
+        return new ol.style.Style({
+          stroke: new ol.style.Stroke({
+            color: boundaryColor,
+            width: boundaryWidth,
+          }),
+          fill: new ol.style.Fill({
+            color: fillColor,
+          }),
+          zIndex: 1
+        });
+      } else {
+        // No gradient → just a solid color. For Hubs, add alpha=0.5
+        let fillColor = isHubs
+          ? convertRgbToRgba(layerColor, 0.5)
+          : layerColor;
+
+        return new ol.style.Style({
+          stroke: new ol.style.Stroke({
+            color: boundaryColor,
+            width: boundaryWidth,
+          }),
+          fill: new ol.style.Fill({
+            color: fillColor,
+          }),
+          zIndex: 1
+        });
+      }
+    }
+
+    // ---- 3) LINESTRINGS ----
+    else if (geometryType === 'LineString' || geometryType === 'MultiLineString') {
+      if (useGradient && bounds) {
+        // Vary stroke width between 1 and 10
+        const normalizedWidth = 1 + 9 * ((attributeValue - bounds.min) / (bounds.max - bounds.min));
         return new ol.style.Style({
           stroke: new ol.style.Stroke({
             color: layerColor,
             width: normalizedWidth,
           }),
-          zIndex: 5  // zIndex between points and polygons
+          zIndex: 5
         });
       } else {
-        // Add default line styling here if you want
         return new ol.style.Style({
           stroke: new ol.style.Stroke({
             color: layerColor,
             width: 3,
           }),
-          zIndex: 5  // zIndex between points and polygons
+          zIndex: 5
         });
       }
-       }
-
-    if (attributeValue === null || attributeValue === undefined) {
-      return null;  // Skip features with undefined or null values
     }
 
-    // For any other geometry type, use default styling
+    // If attributeValue is null or undefined, skip styling
+    if (attributeValue === null || attributeValue === undefined) {
+      return null;
+    }
+
+    // For any other geometry type, use no special styling
     return null;
   };
+}
+
+/**
+ * Helper that, given a color like "rgb(255, 0, 0)" or "#ff0000",
+ * returns an "rgba(r, g, b, alpha)" string for partial transparency.
+ */
+function convertRgbToRgba(rgbStr, alpha) {
+  // If user gave something like "#RRGGBB"
+  if (rgbStr.startsWith('#') && rgbStr.length === 7) {
+    const r = parseInt(rgbStr.slice(1, 3), 16);
+    const g = parseInt(rgbStr.slice(3, 5), 16);
+    const b = parseInt(rgbStr.slice(5, 7), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+  // If it's "rgb(r,g,b)" we can do a quick parse
+  if (rgbStr.startsWith('rgb(')) {
+    // e.g. rgb(255, 100, 50)
+    const nums = rgbStr.match(/\d+/g);
+    const [r, g, b] = nums;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+  // Otherwise just return something default
+  return `rgba(255, 255, 255, ${alpha})`;
 }
 
 function isPolygonLayer(layer) {
   const source = layer.getSource();
   let features = source.getFeatures();
-  if (features.length === 0) return false;  // Empty layer
+  if (features.length === 0) return false;
 
-  // Check the first feature as a sample to determine the type of layer.
-  // This assumes that all features in the layer have the same geometry type.
   const geometryType = features[0].getGeometry().getType();
   return geometryType === 'Polygon' || geometryType === 'MultiPolygon';
 }
@@ -174,10 +208,8 @@ function isPolygonLayer(layer) {
 function isPointLayer(layer) {
   const source = layer.getSource();
   let features = source.getFeatures();
-  if (features.length === 0) return false;  // Empty layer
+  if (features.length === 0) return false;
 
-  // Check the first feature as a sample to determine the type of layer.
-  // This assumes that all features in the layer have the same geometry type.
   const geometryType = features[0].getGeometry().getType();
   return geometryType === 'Point' || geometryType === 'MultiPoint';
 }
@@ -191,6 +223,10 @@ function isLineStringLayer(layer) {
   return geometryType === 'LineString' || geometryType === 'MultiLineString';
 }
 
-
-
-export { createStyleFunction, isPolygonLayer, isPointLayer, isLineStringLayer, assignColorToLayer };
+export {
+  createStyleFunction,
+  isPolygonLayer,
+  isPointLayer,
+  isLineStringLayer,
+  assignColorToLayer
+};

--- a/web/static/styles.js
+++ b/web/static/styles.js
@@ -25,7 +25,6 @@ function generateDistinctColor() {
 }
 
 function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, isHover = false) {
-  console.log("In createStyleFunction for layer", layerName)
   return function(feature) {
     const attributeKey = layerName;
     const useGradient = layerName in selectedGradientAttributes;
@@ -97,8 +96,8 @@ function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, i
 
     // ---- 2) POLYGONS ----
     else if (geometryType === 'Polygon' || geometryType === 'MultiPolygon') {
-      // Check if this is a "_Hubs" layer so that we can do alpha=0.5
-      const isHubs = layerName.includes('_Hubs');
+      // Check if this is a "Hubs" layer so that we can do alpha=0.5
+      const isHubs = layerName.startsWith("ZEF Corridor Strategy Phase") && layerName.includes("Hubs");
 
       if (useGradient && bounds) {
         // We'll apply a simple red/white gradient to the polygon, but for Hubs,

--- a/web/static/styles.js
+++ b/web/static/styles.js
@@ -25,6 +25,7 @@ function generateDistinctColor() {
 }
 
 function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, isHover = false) {
+  console.log("In createStyleFunction for layer", layerName)
   return function(feature) {
     const attributeKey = layerName;
     const useGradient = layerName in selectedGradientAttributes;
@@ -40,7 +41,7 @@ function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, i
     
     // If the layer is pre-defined, set it to its defined color, or default to yellow
     let layerColor = '';
-    if (layerName in dataInfo) {
+    if (layerName in geojsonColors) {
       layerColor = geojsonColors[layerName] || 'yellow'; // Fetch color from dictionary, or default
     } else {
       // Otherwise, set the color dynamically

--- a/web/static/styles.js
+++ b/web/static/styles.js
@@ -24,71 +24,57 @@ function generateDistinctColor() {
   return `hsl(${hue}, 100%, 50%)`;
 }
 
-function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, isHover = false) {
+function createStyleFunction(layerName, boundaryColor = 'gray', boundaryWidth = 1, isHover = false) {
   return function(feature) {
     const attributeKey = layerName;
     const useGradient = layerName in selectedGradientAttributes;
     let attributeName = '';
     let gradientType = '';
     let attributeValue = '';
+    
     if (useGradient) {
       attributeName = selectedGradientAttributes[layerName];
       gradientType = selectedGradientTypes[layerName];
       attributeValue = feature.get(attributeName);
     }
-    const bounds = attributeBounds[layerName]; // Get the bounds for this specific geojson
     
-    // If the layer is pre-defined, set it to its defined color, or default to yellow
-    let layerColor = '';
-    if (layerName in geojsonColors) {
-      layerColor = geojsonColors[layerName] || 'yellow'; // Fetch color from dictionary, or default
-    } else {
-      // Otherwise, set the color dynamically
-      layerColor = assignColorToLayer(layerName);
-    }
+    const bounds = attributeBounds[layerName];
+
+    // Assign layer color dynamically or from predefined settings
+    let layerColor = layerName in geojsonColors ? geojsonColors[layerName] || 'yellow' : assignColorToLayer(layerName);
 
     const geometryType = feature.getGeometry().getType();
-    
+
     // ---- 1) POINTS ----
     if (geometryType === 'Point' || geometryType === 'MultiPoint') {
       if (useGradient && bounds) {
         if (gradientType === 'size') {
-          const minSize = 2; // Minimum point size
-          const maxSize = 10; // Maximum point size
-          const pointSize = minSize + ((maxSize - minSize) *
-            (attributeValue - bounds.min) / (bounds.max - bounds.min));
+          const minSize = 2;
+          const maxSize = 10;
+          const pointSize = minSize + ((maxSize - minSize) * (attributeValue - bounds.min) / (bounds.max - bounds.min));
           return new ol.style.Style({
             image: new ol.style.Circle({
               radius: pointSize,
-              fill: new ol.style.Fill({
-                color: layerColor,
-              }),
+              fill: new ol.style.Fill({ color: layerColor }),
             }),
             zIndex: 10,
           });
         } else if (gradientType === 'color') {
-          const component = Math.floor(255 *
-            (attributeValue - bounds.min) / (bounds.max - bounds.min));
-          const pointColor = `rgb(${component}, 0, ${255 - component})`;
-
+          const component = Math.floor(255 * (attributeValue - bounds.min) / (bounds.max - bounds.min));
+          const pointColor = `rgb(0, ${component}, 255)`; // Light blue to dark blue gradient
           return new ol.style.Style({
             image: new ol.style.Circle({
               radius: 3,
-              fill: new ol.style.Fill({
-                color: pointColor,
-              }),
+              fill: new ol.style.Fill({ color: pointColor }),
             }),
             zIndex: 10,
           });
         }
       }
-      // Default point style if no gradient or bounds are available
       return new ol.style.Style({
         image: new ol.style.Circle({
           radius: 3,
-          fill: new ol.style.Fill({
-            color: layerColor,
-          }),
+          fill: new ol.style.Fill({ color: layerColor }),
         }),
         zIndex: 10,
       });
@@ -96,45 +82,23 @@ function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, i
 
     // ---- 2) POLYGONS ----
     else if (geometryType === 'Polygon' || geometryType === 'MultiPolygon') {
-      // Check if this is a "Hubs" layer so that we can do alpha=0.5
       const isHubs = layerName.startsWith("ZEF Corridor Strategy Phase") && layerName.includes("Hubs");
 
       if (useGradient && bounds) {
-        // We'll apply a simple red/white gradient to the polygon, but for Hubs,
-        // also add alpha=0.5 to the fill color
-        const component = Math.floor(
-          255 - (255 * (attributeValue - bounds.min) / (bounds.max - bounds.min))
-        );
-        // "rgb(255, component, component)" => default
-        // But for Hubs, do "rgba(255, component, component, 0.5)"
-        let fillColor = isHubs
-          ? `rgba(255, ${component}, ${component}, 0.5)`
-          : `rgb(255, ${component}, ${component})`;
+        const component = Math.floor(255 - (255 * (attributeValue - bounds.min) / (bounds.max - bounds.min)));
+        let fillColor = isHubs ? `rgba(${component}, ${component}, 255, 0.5)` : `rgb(${component}, ${component}, 255)`; // White to blue gradient
 
         return new ol.style.Style({
-          stroke: new ol.style.Stroke({
-            color: boundaryColor,
-            width: boundaryWidth,
-          }),
-          fill: new ol.style.Fill({
-            color: fillColor,
-          }),
+          stroke: new ol.style.Stroke({ color: boundaryColor, width: boundaryWidth }),
+          fill: new ol.style.Fill({ color: fillColor }),
           zIndex: 1
         });
       } else {
-        // No gradient → just a solid color. For Hubs, add alpha=0.5
-        let fillColor = isHubs
-          ? convertRgbToRgba(layerColor, 0.5)
-          : layerColor;
+        let fillColor = isHubs ? convertRgbToRgba(layerColor, 0.5) : layerColor;
 
         return new ol.style.Style({
-          stroke: new ol.style.Stroke({
-            color: boundaryColor,
-            width: boundaryWidth,
-          }),
-          fill: new ol.style.Fill({
-            color: fillColor,
-          }),
+          stroke: new ol.style.Stroke({ color: boundaryColor, width: boundaryWidth }),
+          fill: new ol.style.Fill({ color: fillColor }),
           zIndex: 1
         });
       }
@@ -143,7 +107,6 @@ function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, i
     // ---- 3) LINESTRINGS ----
     else if (geometryType === 'LineString' || geometryType === 'MultiLineString') {
       if (useGradient && bounds) {
-        // Vary stroke width between 1 and 10
         const normalizedWidth = 1 + 9 * ((attributeValue - bounds.min) / (bounds.max - bounds.min));
         return new ol.style.Style({
           stroke: new ol.style.Stroke({
@@ -163,12 +126,7 @@ function createStyleFunction(layerName, boundaryColor='gray', boundaryWidth=1, i
       }
     }
 
-    // If attributeValue is null or undefined, skip styling
-    if (attributeValue === null || attributeValue === undefined) {
-      return null;
-    }
-
-    // For any other geometry type, use no special styling
+    if (attributeValue === null || attributeValue === undefined) return null;
     return null;
   };
 }

--- a/web/static/ui.js
+++ b/web/static/ui.js
@@ -1,5 +1,5 @@
 import { geojsonTypes, availableGradientAttributes, selectedGradientAttributes, legendLabels, truckChargingOptions, selectedTruckChargingOptions, stateSupportOptions, selectedStateSupportOptions, tcoOptions, selectedTcoOptions, emissionsOptions, selectedEmissionsOptions, gridEmissionsOptions, hourlyEmissionsOptions, selectedHourlyEmissionsOptions, selectedGridEmissionsOptions, faf5Options, selectedFaf5Options, zefOptions, selectedZefOptions, zefSubLayerOptions, selectedZefSubLayers, fuelLabels, dataInfo } from './name_maps.js';
-import { updateSelectedLayers, updateLegend, updateLayer, data, removeLayer, loadLayer, setLayerVisibility, layerCache, vectorLayers } from './map.js'
+import { updateSelectedLayers, updateLegend, updateLayer, data, removeLayer, loadLayer, toggleZefSubLayer } from './map.js'
 import { geojsonNames } from './main.js'
 
 // Mapping of state abbreviations to full state names
@@ -314,9 +314,9 @@ function createDropdown(name, parameter, dropdown_label, key, options_list, sele
 
     // Ensure all ZEF layers are removed before loading new ones
     for (let phase = 1; phase <= 4; phase++) {
-      removeLayer(`ZEF_Corridor_Strategy_Phase${phase}_Corridors`);
-      removeLayer(`ZEF_Corridor_Strategy_Phase${phase}_Facilities`);
-      removeLayer(`ZEF_Corridor_Strategy_Phase${phase}_Hubs`);
+      removeLayer(`ZEF Corridor Strategy Phase ${phase} Corridors`);
+      removeLayer(`ZEF Corridor Strategy Phase ${phase} Facilities`);
+      removeLayer(`ZEF Corridor Strategy Phase ${phase} Hubs`);
     }
 
     // Load the new layers based on selected options
@@ -390,15 +390,15 @@ function createZefFilenames(selected_options_list) {
 
   if (selectedZefSubLayers["Corridors"]) {
     filenames.push(`${STORAGE_URL}geojsons_simplified/ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase${phase}_Corridors.geojson`);
-    layerNames.push(`ZEF_Corridor_Strategy_Phase${phase}_Corridors`);
+    layerNames.push(`ZEF Corridor Strategy Phase ${phase} Corridors`);
   }
   if (selectedZefSubLayers["Facilities"]) {
     filenames.push(`${STORAGE_URL}geojsons_simplified/ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase${phase}_Facilities.geojson`);
-    layerNames.push(`ZEF_Corridor_Strategy_Phase${phase}_Facilities`);
+    layerNames.push(`ZEF Corridor Strategy Phase ${phase} Facilities`);
   }
   if (selectedZefSubLayers["Hubs"]) {
     filenames.push(`${STORAGE_URL}geojsons_simplified/ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase${phase}_Hubs.geojson`);
-    layerNames.push(`ZEF_Corridor_Strategy_Phase${phase}_Hubs`);
+    layerNames.push(`ZEF Corridor Strategy Phase ${phase} Hubs`);
   }
 
   return { names: layerNames, urls: filenames };
@@ -449,7 +449,6 @@ function createZefDropdowns(key) {
 }
 
 function createZefSubLayerCheckboxes(key) {
-  // If it already exists, remove it
   const existingContainer = document.querySelector(".zef-sub-layers-container");
   if (existingContainer) {
     existingContainer.remove();
@@ -482,31 +481,10 @@ function createZefSubLayerCheckboxes(key) {
         return;
       }
 
-      // Update selectedZefSubLayers
       selectedZefSubLayers[subName] = checkbox.checked;
 
-      const layerName = `ZEF_Corridor_Strategy_Phase${selectedZefOptions["Phase"]}_${subName}`;
-      const layerUrl = `${STORAGE_URL}geojsons_simplified/ZEF_Corridor_Strategy/${layerName}.geojson`;
-
-      if (checkbox.checked) {
-        if (!layerCache[layerName]) {
-          // Load layer if not already loaded
-          await loadLayer(layerName, layerUrl);
-        } else {
-          // Make the layer visible if already loaded
-          setLayerVisibility(layerName, true);
-          if (!vectorLayers.includes(layerCache[layerName])) {
-            vectorLayers.push(layerCache[layerName]);
-            map.addLayer(layerCache[layerName]);
-          }
-        }
-      } else {
-        // Remove the layer when unchecked
-        setLayerVisibility(layerName, false);
-      }
-
-      // Refresh legend
-      updateLegend();
+      // Call function from map.js to update the layers
+      await toggleZefSubLayer(subName, checkbox.checked);
     });
 
     const cbLabel = document.createElement("label");
@@ -522,7 +500,6 @@ function createZefSubLayerCheckboxes(key) {
   addSubLayerCheckbox("Facilities");
   addSubLayerCheckbox("Hubs");
 
-  // Add container to the modal content
   const modalContent = document.querySelector(".modal-content");
   modalContent.appendChild(container);
 }

--- a/web/static/ui.js
+++ b/web/static/ui.js
@@ -576,7 +576,7 @@ document.body.addEventListener('click', function(event) {
         createChargingDropdowns(key);
     }
       // Create a dropdown to select whether to the national zero-emission freight corridor strategy
-    if(key === "National Zero-Emission Freight Corridor Strategy") {
+    if(key === "National ZEF Corridor Strategy") {
         createZefDropdowns(key);
     }
   }

--- a/web/static/ui.js
+++ b/web/static/ui.js
@@ -441,17 +441,26 @@ function createFaf5Dropdowns(key) {
 }
 
 function createZefDropdowns(key) {
-  // 1) The Phase dropdown as you had before
+  // Ensure the dropdowns are only created for the National ZEF Corridor Strategy layer
+  if (key !== "National ZEF Corridor Strategy") {
+    return;
+  }
+
+  // Create the Phase dropdown as before
   createDropdown("phase", "Phase", "Phase: ", key, zefOptions, selectedZefOptions, createZefFilenames);
 
-  // 2) A set of checkboxes for Corridors/Facilities/Hubs
+  // Create checkboxes for Corridors/Facilities/Hubs
   createZefSubLayerCheckboxes(key);
 }
 
+
 function createZefSubLayerCheckboxes(key) {
-  const existingContainer = document.querySelector(".zef-sub-layers-container");
+  // First, check if the modal is already displaying sub-layer checkboxes
+  let existingContainer = document.querySelector(".zef-sub-layers-container");
+
+  // If the sub-layer checkboxes already exist, **do not create them again**
   if (existingContainer) {
-    existingContainer.remove();
+    return;
   }
 
   const container = document.createElement("div");
@@ -500,9 +509,12 @@ function createZefSubLayerCheckboxes(key) {
   addSubLayerCheckbox("Facilities");
   addSubLayerCheckbox("Hubs");
 
+  // Append the container ONLY when necessary
   const modalContent = document.querySelector(".modal-content");
   modalContent.appendChild(container);
 }
+
+
 
 document.body.addEventListener('click', function(event) {
   // Check if a details button was clicked
@@ -740,10 +752,16 @@ function resetModalContent() {
     modalContent.removeChild(chargingPowerDropdownContainer);
   }
 
-  // Remove visualize-by-dropdown-container if it exists
+  // Remove phase dropdown container if it exists
   const phaseDropdownContainer = document.querySelector(".phase-dropdown-container");
   if (phaseDropdownContainer) {
     modalContent.removeChild(phaseDropdownContainer);
+  }
+  
+  // Remove ZEF sub-layer checkboxes container if it exists
+  const zefSubLayerContainer = document.querySelector(".zef-sub-layers-container");
+  if (zefSubLayerContainer) {
+    modalContent.removeChild(zefSubLayerContainer);
   }
 }
 

--- a/web/static/ui.js
+++ b/web/static/ui.js
@@ -1,4 +1,4 @@
-import { geojsonTypes, availableGradientAttributes, selectedGradientAttributes, legendLabels, truckChargingOptions, selectedTruckChargingOptions, stateSupportOptions, selectedStateSupportOptions, tcoOptions, selectedTcoOptions, emissionsOptions, selectedEmissionsOptions, gridEmissionsOptions, hourlyEmissionsOptions, selectedHourlyEmissionsOptions, selectedGridEmissionsOptions, faf5Options, selectedFaf5Options, fuelLabels, dataInfo } from './name_maps.js';
+import { geojsonTypes, availableGradientAttributes, selectedGradientAttributes, legendLabels, truckChargingOptions, selectedTruckChargingOptions, stateSupportOptions, selectedStateSupportOptions, tcoOptions, selectedTcoOptions, emissionsOptions, selectedEmissionsOptions, gridEmissionsOptions, hourlyEmissionsOptions, selectedHourlyEmissionsOptions, selectedGridEmissionsOptions, faf5Options, selectedFaf5Options, zefOptions, selectedZefOptions, fuelLabels, dataInfo } from './name_maps.js';
 import { updateSelectedLayers, updateLegend, updateLayer, data, removeLayer, loadLayer } from './map.js'
 import { geojsonNames } from './main.js'
 
@@ -361,6 +361,10 @@ function createFaf5Filename(selected_options_list) {
   return 'geojsons_simplified/faf5_freight_flows/mode_truck_commodity_' + selected_options_list['Commodity'] + "_origin_all_dest_all.geojson";
 }
 
+function createZefFilename(selected_options_list) {
+  return 'geojsons_simplified/ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase' + selected_options_list['Phase'] + "_Corridors.geojson";
+}
+
 function createChargingDropdowns(key) {
   const rangeDropdownResult = createDropdown("range", "Range", "Truck Range: ", key, truckChargingOptions, selectedTruckChargingOptions, createTruckChargingFilename);
   const chargingTimeDropdownResult = createDropdown("chargingTime", "Charging Time", "Charging Time: ", key, truckChargingOptions, selectedTruckChargingOptions, createTruckChargingFilename);
@@ -394,6 +398,10 @@ function createHourlyEmissionsDropdowns(key) {
 
 function createFaf5Dropdowns(key) {
   const visualizeDropdownResult = createDropdown("commodity", "Commodity", "Commodity: ", key, faf5Options, selectedFaf5Options, createFaf5Filename);
+}
+
+function createZefDropdowns(key) {
+  const visualizeDropdownResult = createDropdown("phase", "Phase", "Phase: ", key, zefOptions, selectedZefOptions, createZefFilename);
 }
 
 document.body.addEventListener('click', function(event) {
@@ -436,11 +444,17 @@ document.body.addEventListener('click', function(event) {
     document.getElementById('details-modal').style.display = 'flex';
 
     // Create a dropdown menu to choose the gradient attribute
-    createAttributeDropdown(key);
+    if (key in availableGradientAttributes) {
+        createAttributeDropdown(key);
+    }
 
     // Create additional dropdown menus for the truck charging layer
     if(key === "Savings from Pooled Charging Infrastructure") {
         createChargingDropdowns(key);
+    }
+      // Create a dropdown to select whether to the national zero-emission freight corridor strategy
+    if(key === "National Zero-Emission Freight Corridor Strategy") {
+        createZefDropdowns(key);
     }
   }
 
@@ -495,8 +509,10 @@ document.getElementById("area-details-button").addEventListener("click", functio
     document.getElementById('details-modal').style.display = 'flex';
 
     // Create a dropdown menu to choose attributes for the area layer
-    createAttributeDropdown(selectedAreaLayerName);
-
+    if (selectedAreaLayerName in availableGradientAttributes) {
+        createAttributeDropdown(selectedAreaLayerName);
+    }
+      
     // Create a dropdown if needed for state-level incentives and support
     if (selectedAreaLayerName === 'State-Level Incentives and Regulations') {
         createStateSupportDropdowns(selectedAreaLayerName)
@@ -519,7 +535,7 @@ document.getElementById("area-details-button").addEventListener("click", functio
     if(selectedAreaLayerName === "Hourly Grid Emissions") {
         createHourlyEmissionsDropdowns(selectedAreaLayerName);
     }
-    // Create a dropdown to select whether to view grid emission by state or balancing authority
+    // Create a dropdown to select whether to view truck imports and exports
     if(selectedAreaLayerName === "Truck Imports and Exports") {
       createFaf5Dropdowns(selectedAreaLayerName);
     }
@@ -622,6 +638,12 @@ function resetModalContent() {
   const chargingPowerDropdownContainer = document.querySelector(".charging-power-dropdown-container");
   if (chargingPowerDropdownContainer) {
     modalContent.removeChild(chargingPowerDropdownContainer);
+  }
+
+  // Remove visualize-by-dropdown-container if it exists
+  const phaseDropdownContainer = document.querySelector(".phase-dropdown-container");
+  if (phaseDropdownContainer) {
+    modalContent.removeChild(phaseDropdownContainer);
   }
 }
 

--- a/web/views.py
+++ b/web/views.py
@@ -130,9 +130,23 @@ geojsons["Energy Demand from Electrified Trucking"] = os.path.join(
     geojson_directory, "trucking_energy_demand.geojson"
 )
 
+for phase in range(1, 5):  # 1,2,3,4
+    geojsons[f"ZEF_Corridor_Strategy_Phase{phase}_Corridors"] = os.path.join(
+        geojson_directory,
+        f"ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase{phase}_Corridors.geojson",
+    )
+    geojsons[f"ZEF_Corridor_Strategy_Phase{phase}_Facilities"] = os.path.join(
+        geojson_directory,
+        f"ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase{phase}_Facilities.geojson",
+    )
+    geojsons[f"ZEF_Corridor_Strategy_Phase{phase}_Hubs"] = os.path.join(
+        geojson_directory,
+        f"ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase{phase}_Hubs.geojson",
+    )
+
 geojsons["National Zero-Emission Freight Corridor Strategy"] = os.path.join(
     geojson_directory,
-    "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Corridors.geojson",
+    "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Corridors.geojson"
 )
 
 

--- a/web/views.py
+++ b/web/views.py
@@ -144,7 +144,7 @@ for phase in range(1, 5):  # 1,2,3,4
         f"ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase{phase}_Hubs.geojson",
     )
 
-geojsons["National Zero-Emission Freight Corridor Strategy"] = [
+geojsons["National ZEF Corridor Strategy"] = [
     os.path.join(geojson_directory, "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Corridors.geojson"),
     os.path.join(geojson_directory, "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Facilities.geojson"),
     os.path.join(geojson_directory, "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Hubs.geojson")

--- a/web/views.py
+++ b/web/views.py
@@ -144,10 +144,11 @@ for phase in range(1, 5):  # 1,2,3,4
         f"ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase{phase}_Hubs.geojson",
     )
 
-geojsons["National Zero-Emission Freight Corridor Strategy"] = os.path.join(
-    geojson_directory,
-    "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Corridors.geojson"
-)
+geojsons["National Zero-Emission Freight Corridor Strategy"] = [
+    os.path.join(geojson_directory, "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Corridors.geojson"),
+    os.path.join(geojson_directory, "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Facilities.geojson"),
+    os.path.join(geojson_directory, "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Hubs.geojson")
+]
 
 
 def auth_required(function):

--- a/web/views.py
+++ b/web/views.py
@@ -131,15 +131,15 @@ geojsons["Energy Demand from Electrified Trucking"] = os.path.join(
 )
 
 for phase in range(1, 5):  # 1,2,3,4
-    geojsons[f"ZEF_Corridor_Strategy_Phase{phase}_Corridors"] = os.path.join(
+    geojsons[f"ZEF Corridor Strategy Phase {phase} Corridors"] = os.path.join(
         geojson_directory,
         f"ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase{phase}_Corridors.geojson",
     )
-    geojsons[f"ZEF_Corridor_Strategy_Phase{phase}_Facilities"] = os.path.join(
+    geojsons[f"ZEF Corridor Strategy Phase {phase} Facilities"] = os.path.join(
         geojson_directory,
         f"ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase{phase}_Facilities.geojson",
     )
-    geojsons[f"ZEF_Corridor_Strategy_Phase{phase}_Hubs"] = os.path.join(
+    geojsons[f"ZEF Corridor Strategy Phase {phase} Hubs"] = os.path.join(
         geojson_directory,
         f"ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase{phase}_Hubs.geojson",
     )

--- a/web/views.py
+++ b/web/views.py
@@ -130,6 +130,11 @@ geojsons["Energy Demand from Electrified Trucking"] = os.path.join(
     geojson_directory, "trucking_energy_demand.geojson"
 )
 
+geojsons["National Zero-Emission Freight Corridor Strategy"] = os.path.join(
+    geojson_directory,
+    "ZEF_Corridor_Strategy/ZEF_Corridor_Strategy_Phase1_Corridors.geojson",
+)
+
 
 def auth_required(function):
     @wraps(function)


### PR DESCRIPTION
This PR adds geospatial layers for corridors, hubs, and facilities laid out in the four phases of the joint office of energy and transport's national zero emission freight corridor infrastructure plan (https://driveelectric.gov/files/zef-corridor-strategy.pdf). 

In doing so, it adds functionality to simultaneously show multiple sub-layers for a singled checked box on the main interface, as well as check boxes in the corresponding modal to select which sub-layers are visible. 

In addition, I updated the color gradient for area layers from reds to blues, per Prof. Mueller's suggestion. 