### PR TITLE
Dynamically extend blue background to full legend width

### DIFF
--- a/web/static/map.js
+++ b/web/static/map.js
@@ -645,10 +645,7 @@ function updateLegend() {
     if (layers.length === 0) return;
 
     const groupWrapper = document.createElement('div');
-    groupWrapper.style.backgroundColor = 'rgb(240, 246, 248)';
-    groupWrapper.style.padding = '5px';
-    groupWrapper.style.marginBottom = '5px';
-    groupWrapper.style.borderRadius = '5px';
+    groupWrapper.className = 'legend-group';
 
     layers.forEach((layer) => {
       const layerName = layer.get('key');
@@ -656,9 +653,7 @@ function updateLegend() {
       const isNew = !previouslyRenderedLegendKeys.has(layerName);
 
       const layerDiv = document.createElement('div');
-      layerDiv.style.display = 'flex';
-      layerDiv.style.alignItems = 'center';
-      layerDiv.style.marginBottom = '4px';
+      layerDiv.className = 'legend-entry';
 
       const symbolContainer = document.createElement('div');
       symbolContainer.style.display = 'flex';
@@ -700,15 +695,13 @@ function updateLegend() {
 
       layerDiv.appendChild(symbolContainer);
       layerDiv.appendChild(title);
-      groupWrapper.appendChild(layerDiv);
 
       if (isNew) {
         layerDiv.classList.add('legend-fadeout-start');
         groupWrapper.appendChild(layerDiv);
-
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
-            layerDiv.classList.add('fadeout'); // triggers fade from yellow
+            layerDiv.classList.add('fadeout');
           });
         });
       } else {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -658,6 +658,25 @@ ul {
   white-space: nowrap; /* Prevent legend entries from wrapping */
 }
 
+.legend-group {
+  background-color: rgb(240, 246, 248);
+  padding: 5px;
+  margin-bottom: 5px;
+  border-radius: 5px;
+  display: table;        /* expands to widest child */
+  width: 100%;
+  box-sizing: border-box;
+}
+
+
+.legend-entry {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+  white-space: nowrap;
+  box-sizing: border-box;
+}
+
 #layer-selection {
   max-height: 60vh; /* Layer selection can grow taller */
   overflow-y: auto;


### PR DESCRIPTION
This PR updates the map.js and style.css to allow the blue background behind legend entry categories to dynamically extend to the full scrollable legend width when entries exceed the nominal legend width.