### PR TITLE
fix: Use 'workspace' over deprecated 'project' table field

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This repo contains code to produce and interactively visualize publicly availabl
 
 The code in [web](./web) contains all functionality to visualize the geojsons interactively on a web interface. To deploy a local instance of the tool:
 
-```bash 
-pixi run runserver
+```bash
+pixi run start
 ```
 
 If that executes without issue, you should be able to view the map in your browser at http://127.0.0.1:5000/transportation. It currently looks something like this:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The code in [web](./web) contains all functionality to visualize the geojsons in
 pixi run start
 ```
 
-If that executes without issue, you should be able to view the map in your browser at http://127.0.0.1:5000/transportation. It currently looks something like this:
+If that executes without issue, you should be able to view the map in your browser at http://127.0.0.1:8000/transportation. It currently looks something like this:
 
 ![Interactive Web Map](./images/web_map.png)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,8 +6,12 @@ authors = ["Danika MacDonell <danikam@mit.edu>"]
 channels = ["conda-forge"]
 platforms = ["osx-arm64", "osx-64", "linux-64", "win-64"]
 
-[tasks]
-runserver = "python manage.py runserver"
+[tasks.runserver]
+description = "Launch interactive web interface"
+cmd = "python manage.py runserver"
+
+[tasks.start]
+depends-on = ["runserver"]
 
 [dependencies]
 django = ">=5.0.7,<6"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "Geo-TIDE"
 version = "0.1.0"
 description = "MCSC Geospatial Trucking Industry Decarbonization Explorer"


### PR DESCRIPTION
* In modern versions of Pixi the 'project' table has been renamed to 'workspace'. This avoids the warning

> The `project` field is deprecated. Use `workspace` instead.

* Add description to 'runserver' Pixi task.
* Add canonical 'start' task.
* Update README to use canonical 'start' task for getting going.
* Update README to note to use port 8000, the default Django development server port that is launched.