### PR TITLE
Updates to restore uploaded data pillbox appearance

### DIFF
--- a/web/static/panels.js
+++ b/web/static/panels.js
@@ -66,7 +66,7 @@ function toggleUploadedData() {
   
   if (uploadedDataOpen) {
     content.style.display = 'block';
-    uploadedPanel.style.height = '6.75rem';
+    uploadedPanel.style.height = 'auto';
     uploadedPanel.style.width = '19.5rem';
     chevron.setAttribute('d', 'm6 6 6 6 6-6M6 12l6 6 6-6');
   } else {
@@ -115,6 +115,22 @@ document.addEventListener('DOMContentLoaded', function() {
   setTimeout(() => placePanels(), 50);
   initPanelToggles();
   initH3SectionToggles();
+
+  // keep GAP consistent when panel heights change
+  if ('ResizeObserver' in window) {
+    const uploaded = document.getElementById('uploaded-layer-selection');
+    const publicPanel = document.getElementById('layer-selection');
+
+    const ro = new ResizeObserver(() => {
+      // Whenever either panel’s height changes (e.g. more pillboxes),
+      // recompute their positions so the GAP stays constant.
+      placePanels();
+    });
+
+    if (uploaded) ro.observe(uploaded);
+    if (publicPanel) ro.observe(publicPanel);
+  }
+
   window.addEventListener('resize', placePanels);
 });
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -749,62 +749,6 @@ ul {
 
 /* Consolidated Select2 selection styling */
 
-#uploaded-layer-selection .select2-selection__rendered {
-  line-height: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-}
-
-#uploaded-layer-selection .select2-container .select2-selection--multiple .select2-selection__placeholder {
-  text-align: left;
-  justify-content: flex-start;
-  text-overflow: ellipsis;
-  width: 100%;
-  max-width: 14rem;
-  padding: 0;
-  margin: 0;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  height: 100%;
-  vertical-align: middle;
-}
-
-.uploaded-layer-pill {
-  background-color: #e4e4e4;
-  border-radius: 3px;
-  padding: 1px 4px; /* Tighten horizontal padding */
-  margin: 5px 2px; /* Adjust spacing between pills */
-  display: inline-flex;
-  align-items: center; /* Vertically center contents */
-  font-size: var(--font-size-sm);
-  height: 24px; /* Fixed height for the pill */
-  line-height: 1; /* Remove extra line height */
-  box-sizing: border-box; /* Ensure padding doesn't add height */
-}
-
-/* Custom pill container */
-.select2-container .uploaded-layer-pill,
-.select2-results__option .uploaded-layer-pill {
-  font-family: var(--font-family-sans, 'Inter', system-ui, -apple-system, "Segoe UI",
-                   Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif);
-  font-size: var(--font-size-sm);
-  font-weight: normal;
-  color: var(--theme-accent-foreground, #0F172B);
-}
-
-/* Inner text and the "More" button inherit the same font */
-.select2-container .uploaded-layer-pill > span,
-.select2-container .uploaded-layer-pill .details-btn {
-  font: inherit;
-  color: inherit;
-  line-height: var(--font-leading-5, 1.25rem);
-}
 
 /* Force smaller X and correct vertical alignment */
 .select2-container--default
@@ -848,65 +792,6 @@ ul {
 .select2-container--default .select2-selection--multiple .select2-selection__choice .select2-selection__choice__remove {
   font: inherit;
   line-height: inherit;
-}
-
-
-#uploaded-layer-selection .select2-container--default .select2-selection--multiple {
-  display: flex;
-  height: var(--spacing-10, 2.5rem);
-  padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
-  align-items: center;
-  justify-content: flex-start;
-  gap: var(--spacing-2, 0.5rem);
-  align-self: stretch;
-  border-radius: var(--radius-md, 0.375rem);
-  border: 1px solid var(--Border-Primary, #E2E8F0);
-  opacity: var(--opacity-100, 1);
-  background: var(--Background-Light, #FFF);
-  box-sizing: border-box;
-  max-width: 19rem;
-  overflow: hidden;
-}
-
-#uploaded-layer-selection .select2-container--default .select2-selection--multiple .select2-selection__choice {
-  height: 1.5rem;
-  display: inline-flex;
-  align-items: center;
-  box-sizing: border-box;
-  max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-#uploaded-data-content {
-  display: flex;
-  justify-content: center;
-  padding: 0;
-}
-
-#uploaded-layer-selection .select2-container.select2-container--default {
-  margin: 0;
-  width: 18rem !important;
-  max-width: 18rem !important;
-  overflow: visible;
-}
-
-#uploaded-layer-selection .select2-container--default .select2-search--inline .select2-search__field {
-  min-width: 14rem;
-  width: 14rem;
-  box-sizing: border-box;
-  text-align: left;
-  padding: 0;
-  margin: 0;
-  margin-left: -0.5rem;
-  line-height: 2.5rem;
-  height: 2.5rem;
-  font-family: var(--font-family-sans, 'Inter', system-ui, -apple-system, "Segoe UI",
-                   Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif);
-  font-size: var(--font-size-sm);
-  font-weight: normal;
-  color: var(--theme-accent-foreground, #0F172B);
 }
 
 /* Dropdown options + “No results” message */
@@ -1135,25 +1020,6 @@ ul {
   box-sizing: border-box;
 }
 
-#uploaded-layer-selection {
-  position: absolute;
-  right: 1rem;
-  display: flex;
-  width: 19.5rem;
-  height: 6.75rem;
-  padding: 0.75rem;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 1rem;
-  flex-shrink: 0;
-  border-radius: var(--Corner-Small, 0.5rem);
-  background: #FFF;
-  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.30), 0px 2px 6px 2px rgba(0, 0, 0, 0.15);
-  box-sizing: border-box;
-  overflow: hidden;
-}
-
-
 .separator {
   display: block;
   left: 0.75rem;
@@ -1246,15 +1112,6 @@ ul {
 /* Unified panel header styles */
 .panel-header,
 .public-data-header,
-.uploaded-panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  cursor: pointer;
-  border-radius: 0.25rem;
-  transition: background-color 0.2s ease;
-}
 
 .public-data-header {
   margin-bottom: 0.75rem;
@@ -1265,13 +1122,6 @@ ul {
 .panel-header {
   margin: 2px 14px 8px 14px;
 }
-
-.uploaded-panel-header {
-  margin-bottom: 0;
-  padding: 0.5rem;
-  margin: -0.5rem -0.75rem -0.5rem -0.25rem;
-}
-
 
 .panel-title {
   color: var(--theme-foreground, #020618);
@@ -1467,23 +1317,140 @@ ul {
   padding: 0;
 }
 
-/* Fix Select2 multiple selection placeholder positioning */
-#uploaded-layer-selection .select2-container--default .select2-selection--multiple .select2-search--inline {
-  display: contents;
+
+/* Styling for uploaded layer selection */
+.uploaded-layer-pill {
+  background-color: #e4e4e4;
+  border-radius: 3px;
+  padding: 1px 4px; /* Tighten horizontal padding */
+  margin: 2px 2px;
+  display: inline-flex;
+  align-items: center; /* Vertically center contents */
+  font-size: var(--font-size-sm);
+  height: 24px; /* Fixed height for the pill */
+  line-height: 1; /* Remove extra line height */
+  box-sizing: border-box; /* Ensure padding doesn't add height */
 }
 
-#uploaded-layer-selection .select2-container--default .select2-selection--multiple .select2-search__field:placeholder-shown {
+/* Custom pill container */
+.select2-container .uploaded-layer-pill,
+.select2-results__option .uploaded-layer-pill {
+  font-family: var(--font-family-sans, 'Inter', system-ui, -apple-system, "Segoe UI",
+                   Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif);
+  font-size: var(--font-size-sm);
+  font-weight: normal;
+  color: var(--theme-accent-foreground, #0F172B);
+}
+
+/* Inner text and the "More" button inherit the same font */
+.select2-container .uploaded-layer-pill > span,
+.select2-container .uploaded-layer-pill .details-btn {
+  font: inherit;
+  color: inherit;
+  line-height: var(--font-leading-5, 1.25rem);
+}
+
+#uploaded-layer-selection .select2-selection__choice {
+  height: 1.5rem !important; /* Force exact height */
+  display: inline-flex !important; /* Match your flex layout */
+  align-items: center !important; /* Vertical centering */
+  box-sizing: border-box !important; /* Prevent padding from adding height */
+  max-width: 14rem;           /* sets a horizontal cap */
+  white-space: nowrap;        /* prevent wrapping text */
+  overflow: hidden;           /* hide overflow */
+  text-overflow: ellipsis;    /* show "…" if truncated */
+}
+
+#uploaded-layer-selection .select2-container {
+  margin-top: 1rem;
+  min-width: 16rem !important; /* Set your desired minimum */
+  width: auto !important; /* Allow it to expand beyond the minimum */
+  max-width: 100%; /* Prevent overflow beyond parent container */
+}
+
+#uploaded-layer-selection .select2-search__field {
+  min-width: 100% !important; /* Ensure it expands fully */
   width: 100% !important;
+  box-sizing: border-box; /* Prevent overflow */
+  font-family: var(--font-family-sans, 'Inter', system-ui, -apple-system, "Segoe UI",
+                   Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif);
+  font-size: var(--font-size-sm);
+  font-weight: normal;
+  color: var(--theme-accent-foreground, #0F172B);
+}
+
+#uploaded-layer-selection {
+  position: absolute;
+  width: 19.5rem;
+  flex-shrink: 0;
+  border-radius: var(--Corner-Small, 0.5rem);
+  background: #FFF;
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.30), 0px 2px 6px 2px rgba(0, 0, 0, 0.15);
+  padding: 10px;
+  right: 1rem;
+  box-sizing: border-box;
 }
 
 .uploaded-data-container{
   position: absolute;
   top: 275px;
   right: 10px;
-  width: 50rem;
+  width: 19.5rem;
   height: 6.75rem;
   flex-shrink: 0;
   border-radius: var(--Corner-Small, 0.5rem);
   background: #FFF;
   box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.30), 0px 2px 6px 2px rgba(0, 0, 0, 0.15);
 }
+
+/* The visible "pillbox" area */
+#uploaded-layer-selection .select2-selection--multiple {
+  align-items: flex-start;
+  box-sizing: border-box !important;
+
+  /* FIXED height – this is what stops it growing */
+  height: 4rem !important;       /* tweak to your desired two-row height */
+  max-height: 4rem !important;
+
+  padding: 2px 4px !important;
+  overflow: hidden;               /* overflow handled by inner UL */
+  
+  display: block !important;         /* undo flex */
+  width: 100% !important;
+  box-sizing: border-box !important;
+
+  overflow-y: auto !important;       /* scroll when there are many pills */
+  overflow-x: hidden !important;     /* no horizontal scroll */
+  
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  height: auto !important;
+  min-height: 0 !important;
+  box-sizing: border-box !important;
+  line-height: 1 !important;
+}
+
+/* The UL that actually contains the pills + search input */
+#uploaded-layer-selection .select2-selection__rendered {
+  flex-direction: column !important;   /* stack items vertically */
+  flex-wrap: nowrap !important;        /* ⬅ prevent new columns to the right */
+  align-items: flex-start !important;
+  width: 100%;
+  box-sizing: border-box;
+
+  overflow-y: auto;
+  overflow-x: hidden;
+  margin: 0;
+  padding: 0;
+  
+  display: block !important;         /* undo flex */
+  max-height: none !important;       /* parent handles the clipping */
+  overflow: visible !important;      /* no need to scroll here */
+  
+  max-height: none !important;       /* parent handles the clipping */
+  overflow: visible !important;      /* no need to scroll here */
+}
+
+
+
+


### PR DESCRIPTION
This PR adds the following updates:
* Restores the appearance of uploaded layer pillboxes (were previously horizontally clipped and all on the same line)
* Adds functionality to introduce scrolling beyond one pillbox to keep the uploaded layer box height acceptable
* Updates panels.js functions to maintain constant gap between uploaded and public layer boxes when uploaded layer box height increases, and to return to automatic height when chevron is re-opened.

Sample screenshots:
<img width="339" height="584" alt="Screenshot 2025-11-13 at 9 55 44 PM" src="https://github.com/user-attachments/assets/acadd313-f173-46d9-83a5-a651c6893260" />
<img width="339" height="585" alt="Screenshot 2025-11-13 at 9 55 51 PM" src="https://github.com/user-attachments/assets/b3f2a54f-2784-41e4-abaa-df261206f3bf" />
<img width="335" height="547" alt="Screenshot 2025-11-13 at 9 56 04 PM" src="https://github.com/user-attachments/assets/d2c7e81d-8df6-4c2d-a7ba-ecba403dbb82" />

